### PR TITLE
Debug deployed website issues

### DIFF
--- a/frontend/public/static.json
+++ b/frontend/public/static.json
@@ -1,0 +1,5 @@
+{
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}

--- a/frontend/src/components/pages/CanvasPage.jsx
+++ b/frontend/src/components/pages/CanvasPage.jsx
@@ -95,10 +95,7 @@ const CanvasPage = () => {
     socketRef.current.on("connect", () => {
       console.log(`Connected to WebSocket server with socket ID: ${socketRef.current.id}`);
       console.log(`Joining canvas ${canvasid} as user ${userEmail}`);
-      socketRef.current.emit("joinCanvas", { // Changed to match backend event name
-        canvasId: canvasid,
-        userEmail: userEmail,
-      });
+      socketRef.current.emit("joinCanvas", canvasid);
     });
 
     socketRef.current.on("disconnect", (reason) => {
@@ -119,8 +116,8 @@ const CanvasPage = () => {
       }));
     });
 
-    socketRef.current.on("userJoined", (data) => { // Changed to match backend event name
-      console.log(`User ${data.userEmail} joined the canvas ${data.canvasId}`);
+    socketRef.current.on("userJoined", (data) => {
+      console.log(`User ${data.userEmail} joined the canvas`);
     });
 
     socketRef.current.on("user left", (data) => {


### PR DESCRIPTION
Add SPA fallback routing for Render and fix the WebSocket canvas join payload to resolve 404 errors on refresh and ensure canvases load correctly.

The 404 errors on refresh for routes like `/profile` and `/canvas/:id` were caused by the static server not being configured to handle client-side routing, which `static.json` now addresses. Canvases were not loading because the frontend's `joinCanvas` WebSocket event payload did not match the backend's expected `canvasId` string.

---
<a href="https://cursor.com/background-agent?bcId=bc-627359be-f924-4c0a-a511-09d27b4770fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-627359be-f924-4c0a-a511-09d27b4770fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

